### PR TITLE
feat(core): add optional token

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,4 +6,9 @@ export {
   UnknownDependencyTree,
 } from './injectable'
 export { provide } from './provide'
-export { TokenAccessor, TOKEN_ACCESSOR_KEY, token } from './token'
+export {
+  TokenAccessor,
+  TOKEN_ACCESSOR_KEY,
+  token,
+  tokenOptional,
+} from './token'

--- a/packages/core/src/token.spec.ts
+++ b/packages/core/src/token.spec.ts
@@ -1,6 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { token, TOKEN_ACCESSOR_KEY, TokenAccessor } from './token'
-import { InjectableDependencies, InjectableValue } from './injectable'
+import {
+  token,
+  TOKEN_ACCESSOR_KEY,
+  TokenAccessor,
+  tokenOptional,
+} from './token'
+import {
+  injectable,
+  InjectableDependencies,
+  InjectableValue,
+} from './injectable'
 
 describe('token', () => {
   it('returns passed value as result', () => {
@@ -25,5 +34,15 @@ describe('token', () => {
     // $ExpectType "bar"
     const result = foo({ [TOKEN_ACCESSOR_KEY]: accessor, foo: 'bar' })
     expect(cb).toHaveBeenCalledWith('bar')
+  })
+  it('return optional token result', () => {
+    const foo = tokenOptional('foo')<'foo'>()
+
+    const bar = injectable(foo, (foo) =>
+      foo !== undefined ? `${foo}bar` : 'baz'
+    )
+
+    expect(bar({ foo: 'foo' })).toBe('foobar')
+    expect(bar({})).toBe('baz')
   })
 })

--- a/packages/core/src/token.ts
+++ b/packages/core/src/token.ts
@@ -32,3 +32,17 @@ export function token<Name extends PropertyKey>(name: Name) {
     }
   }
 }
+
+export function tokenOptional<Name extends PropertyKey>(name: Name) {
+  return <Type = never>(): Injectable<
+    {
+      readonly name: Name
+      readonly type: Type | undefined
+      readonly optional: true
+      readonly children: readonly []
+    },
+    Type | undefined
+  > => {
+    return (dependencies) => dependencies[name]
+  }
+}


### PR DESCRIPTION
Sometimes some dependencies are optional, but now there is no way to specify such dependencies correctly.

My suggestion is to add an optional token:
```ts
const foo = tokenOptional('foo')<'foo'>()

const bar = injectable(foo, (foo: 'foo' | undefined) =>
  foo !== undefined ? `${foo}bar` : 'baz'
)

bar({}) // ✅ valid
```