### PR TITLE
feat: @frp-ts/utils bumped to 1.0.0-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,9 +1101,9 @@
       }
     },
     "node_modules/@frp-ts/utils": {
-      "version": "1.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@frp-ts/utils/-/utils-1.0.0-alpha.15.tgz",
-      "integrity": "sha512-i0BEI3a2jJXypaX0jARiSoA2uMNIHe7mnhxqMPfmf7Qv/jOWhlYpRe/GVSqpk7+wsTuGMjK1XArlI6uWynEXDQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@frp-ts/utils/-/utils-1.0.0-beta.3.tgz",
+      "integrity": "sha512-cW7dfip8dgspExzDdYQISPvSq1sKyWaY0DJ9AaYtqRxVNrS+j5/S2wpuSkrXlf47k5hhYq6Lu9q9n2uu6kPGQA==",
       "peerDependencies": {
         "tslib": "^2.3.1"
       }
@@ -17162,7 +17162,7 @@
       "name": "@injectable-ts/core",
       "version": "1.0.0-alpha.3",
       "dependencies": {
-        "@frp-ts/utils": "^1.0.0-alpha.15"
+        "@frp-ts/utils": "^1.0.0-beta.3"
       }
     },
     "packages/fp-ts": {
@@ -17988,9 +17988,9 @@
       }
     },
     "@frp-ts/utils": {
-      "version": "1.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@frp-ts/utils/-/utils-1.0.0-alpha.15.tgz",
-      "integrity": "sha512-i0BEI3a2jJXypaX0jARiSoA2uMNIHe7mnhxqMPfmf7Qv/jOWhlYpRe/GVSqpk7+wsTuGMjK1XArlI6uWynEXDQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@frp-ts/utils/-/utils-1.0.0-beta.3.tgz",
+      "integrity": "sha512-cW7dfip8dgspExzDdYQISPvSq1sKyWaY0DJ9AaYtqRxVNrS+j5/S2wpuSkrXlf47k5hhYq6Lu9q9n2uu6kPGQA==",
       "requires": {}
     },
     "@gar/promisify": {
@@ -18025,7 +18025,7 @@
     "@injectable-ts/core": {
       "version": "file:packages/core",
       "requires": {
-        "@frp-ts/utils": "^1.0.0-alpha.15"
+        "@frp-ts/utils": "^1.0.0-beta.3"
       }
     },
     "@injectable-ts/fp-ts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0-alpha.3",
   "type": "commonjs",
   "dependencies": {
-    "@frp-ts/utils": "^1.0.0-alpha.15"
+    "@frp-ts/utils": "^1.0.0-beta.3"
   }
 }


### PR DESCRIPTION
Hi! We encounter dependencies conflicts using `@injectable-ts/core@1.0.0-alpha.3` together with `@frp-ts/lens@1.0.0-beta.3`. Updating `@frp-ts/utils` in this package to the last available version (i.e. `1.0.0-beta.3`) should fix the conflict.